### PR TITLE
Update Dockerfile to install dependencies without frozen lock

### DIFF
--- a/src/phase2-final/frontend/Dockerfile
+++ b/src/phase2-final/frontend/Dockerfile
@@ -4,7 +4,8 @@
 FROM oven/bun:1.2-alpine AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
-RUN bun install --frozen-lockfile
+# RUN bun install --frozen-lockfile
+RUN bun install
 
 # ── builder: build Next.js standalone ────────────────────────────────────────
 FROM oven/bun:1.2-alpine AS builder


### PR DESCRIPTION
Removed the frozen lockfile option from the install command.