### PR TITLE
Comment out lighthouse dependency in deployment

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -227,7 +227,7 @@ steps:
     image: *kubectl_image
     depends_on:
       - trivy-scan
-      - lighthouse
+      # - lighthouse
     when:
       event: push
       branch: main


### PR DESCRIPTION
Comment out the lighthouse dependency in the deploy-k3s step.