### PR TITLE
fix: add path filters to sign/sbom/trivy steps to match build-push

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -274,6 +274,11 @@ services:
     when:
       event: push
       branch: main
+      path:
+        include:
+          - "src/phase2-final/backend/**"
+          - "src/phase2-final/frontend/**"
+          - ".woodpecker.yml"
     environment:
       COSIGN_PASSWORD:
         from_secret: COSIGN_PASSWORD
@@ -298,6 +303,11 @@ services:
     when:
       event: push
       branch: main
+      path:
+        include:
+          - "src/phase2-final/backend/**"
+          - "src/phase2-final/frontend/**"
+          - ".woodpecker.yml"
     environment:
       DOCKER_USERNAME: { from_secret: DOCKER_USERNAME }
       DOCKER_PASSWORD: { from_secret: DOCKER_PASSWORD }
@@ -330,6 +340,11 @@ services:
     when:
       event: push
       branch: main
+      path:
+        include:
+          - "src/phase2-final/backend/**"
+          - "src/phase2-final/frontend/**"
+          - ".woodpecker.yml"
     environment:
       TRIVY_USERNAME: { from_secret: DOCKER_USERNAME }
       TRIVY_PASSWORD: { from_secret: DOCKER_PASSWORD }


### PR DESCRIPTION
When build-push-core/web are skipped (no backend/frontend changes), sign-images, sbom-attest, and trivy-scan must also skip — otherwise they try to sign/scan images that were never built (MANIFEST_UNKNOWN).

Woodpecker depends_on = ordering only, not success-gating. Path filters ensure all image-dependent steps are skipped together.