### PR TITLE
fix: use git rev-parse to get commit SHA in tag-release pipeline

### DIFF
--- a/.woodpecker/tag-release.yml
+++ b/.woodpecker/tag-release.yml
@@ -14,9 +14,9 @@ steps:
     image: *alpine_image
     commands:
       - apk add --no-cache git
-      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at "$CI_COMMIT_SHA" | sort -V | tail -n 1)}"
+      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at HEAD | sort -V | tail -n 1)}"
       - echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'
-      - echo "✅ release tag $RELEASE_TAG is valid"
+      - 'printf "release tag %s is valid\n" "$RELEASE_TAG"'
 
   - name: retag-release-images
     image: *skopeo_image
@@ -28,7 +28,7 @@ steps:
       - apk add --no-cache skopeo git
       - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at HEAD | sort -V | tail -n 1)}"
       - SHA_TAG=$(git rev-parse "${RELEASE_TAG}^{}" | cut -c1-7)
-      - echo "Release tag: $RELEASE_TAG  →  source SHA tag: $SHA_TAG"
+      - 'printf "Release tag: %s -> source SHA tag: %s\n" "$RELEASE_TAG" "$SHA_TAG"'
       - skopeo login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD" docker.io
       - skopeo copy --all "docker://docker.io/akawatmor/todoapp-core:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-core:${RELEASE_TAG}"
       - skopeo copy --all "docker://docker.io/akawatmor/todoapp-web:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-web:${RELEASE_TAG}"

--- a/.woodpecker/tag-release.yml
+++ b/.woodpecker/tag-release.yml
@@ -25,9 +25,10 @@ steps:
       DOCKER_USERNAME: { from_secret: DOCKER_USERNAME }
       DOCKER_PASSWORD: { from_secret: DOCKER_PASSWORD }
     commands:
-      - apk add --no-cache skopeo
-      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at "$CI_COMMIT_SHA" | sort -V | tail -n 1)}"
-      - SHA_TAG=$(printf '%s' "$CI_COMMIT_SHA" | cut -c1-7)
+      - apk add --no-cache skopeo git
+      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at HEAD | sort -V | tail -n 1)}"
+      - SHA_TAG=$(git rev-parse "${RELEASE_TAG}^{}" | cut -c1-7)
+      - echo "Release tag: $RELEASE_TAG  →  source SHA tag: $SHA_TAG"
       - skopeo login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD" docker.io
       - skopeo copy --all "docker://docker.io/akawatmor/todoapp-core:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-core:${RELEASE_TAG}"
       - skopeo copy --all "docker://docker.io/akawatmor/todoapp-web:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-web:${RELEASE_TAG}"

--- a/src/phase2-final/monitoring/alertmanager-config.yaml
+++ b/src/phase2-final/monitoring/alertmanager-config.yaml
@@ -31,7 +31,7 @@ spec:
       emailConfigs:
         - to: PLACEHOLDER_NOTIFY_EMAIL
           from: PLACEHOLDER_SMTP_USERNAME
-          smarthost: PLACEHOLDER_SMTP_HOST:465
+          smarthost: "PLACEHOLDER_SMTP_HOST:465"
           authUsername: PLACEHOLDER_SMTP_USERNAME
           authPassword:
             name: kps-alertmanager-smtp

--- a/src/phase2-final/monitoring/alertmanager-config.yaml
+++ b/src/phase2-final/monitoring/alertmanager-config.yaml
@@ -12,12 +12,21 @@ metadata:
     app.kubernetes.io/part-of: todoapp
 spec:
   route:
-    receiver: email-kps
+    receiver: null-receiver        # default: ไม่ส่งอีเมล
     groupBy: ['alertname', 'namespace']
     groupWait: 30s
     groupInterval: 5m
-    repeatInterval: 12h
+    repeatInterval: 24h
+    routes:
+      - receiver: email-kps
+        matchers:
+          - name: severity
+            value: critical
+        groupWait: 30s
+        groupInterval: 5m
+        repeatInterval: 24h       # ส่งซ้ำทุก 24h ถ้ายังไม่ resolved
   receivers:
+    - name: null-receiver          # รับแต่ไม่ทำอะไร (absorb warning/info alerts)
     - name: email-kps
       emailConfigs:
         - to: PLACEHOLDER_NOTIFY_EMAIL


### PR DESCRIPTION
CI_COMMIT_SHA is empty/wrong in tag events — dereference the tag
with 'git rev-parse "${RELEASE_TAG}^{}"' to get the actual commit
SHA that the image was built from.