### PR TITLE
fix(tag-release): use | blocks to share variables + git fetch --tags …

### DIFF
--- a/.woodpecker/tag-release.yml
+++ b/.woodpecker/tag-release.yml
@@ -13,10 +13,11 @@ steps:
   - name: validate-release-tag
     image: *alpine_image
     commands:
-      - apk add --no-cache git
-      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at HEAD | sort -V | tail -n 1)}"
-      - echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'
-      - 'printf "release tag %s is valid\n" "$RELEASE_TAG"'
+      - |
+        RELEASE_TAG="${CI_COMMIT_TAG}"
+        echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          || { echo "ERROR: invalid tag format: $RELEASE_TAG"; exit 1; }
+        echo "release tag $RELEASE_TAG is valid"
 
   - name: retag-release-images
     image: *skopeo_image
@@ -25,14 +26,16 @@ steps:
       DOCKER_USERNAME: { from_secret: DOCKER_USERNAME }
       DOCKER_PASSWORD: { from_secret: DOCKER_PASSWORD }
     commands:
-      - apk add --no-cache skopeo git
-      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at HEAD | sort -V | tail -n 1)}"
-      - SHA_TAG=$(git rev-parse "${RELEASE_TAG}^{}" | cut -c1-7)
-      - 'printf "Release tag: %s -> source SHA tag: %s\n" "$RELEASE_TAG" "$SHA_TAG"'
-      - skopeo login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD" docker.io
-      - skopeo copy --all "docker://docker.io/akawatmor/todoapp-core:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-core:${RELEASE_TAG}"
-      - skopeo copy --all "docker://docker.io/akawatmor/todoapp-web:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-web:${RELEASE_TAG}"
-      - echo "✅ Docker Hub tags published for $RELEASE_TAG"
+      - |
+        apk add --no-cache skopeo git
+        RELEASE_TAG="${CI_COMMIT_TAG}"
+        git fetch --tags --quiet
+        SHA_TAG=$(git rev-list -n 1 "$RELEASE_TAG" | cut -c1-7)
+        echo "Release tag: $RELEASE_TAG -> source SHA tag: $SHA_TAG"
+        skopeo login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD" docker.io
+        skopeo copy --all "docker://docker.io/akawatmor/todoapp-core:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-core:${RELEASE_TAG}"
+        skopeo copy --all "docker://docker.io/akawatmor/todoapp-web:${SHA_TAG}" "docker://docker.io/akawatmor/todoapp-web:${RELEASE_TAG}"
+        echo "Docker Hub tags published for $RELEASE_TAG"
 
   - name: create-github-release
     image: *alpine_image
@@ -40,13 +43,16 @@ steps:
     environment:
       GITHUB_TOKEN: { from_secret: GITHUB_TOKEN }
     commands:
-      - apk add --no-cache curl jq git
-      - ': "${GITHUB_TOKEN:?missing GITHUB_TOKEN secret}"'
-      - RELEASE_TAG="${CI_COMMIT_TAG:-$(git tag --points-at "$CI_COMMIT_SHA" | sort -V | tail -n 1)}"
       - |
+        apk add --no-cache curl jq git
+        : "${GITHUB_TOKEN:?missing GITHUB_TOKEN secret}"
+        RELEASE_TAG="${CI_COMMIT_TAG}"
+        git fetch --tags --quiet
+        COMMIT_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
+
         PAYLOAD=$(jq -nc \
           --arg tag "$RELEASE_TAG" \
-          --arg target "$CI_COMMIT_SHA" \
+          --arg target "$COMMIT_SHA" \
           '{tag_name:$tag,target_commitish:$target,name:$tag,draft:false,prerelease:false,generate_release_notes:true}')
 
         STATUS=$(curl -sS -o /tmp/release.json -w '%{http_code}' \
@@ -63,7 +69,7 @@ steps:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/Akawatmor/KPS-Enterprise/releases/$RELEASE_ID" \
             -d "$PAYLOAD" >/tmp/release-updated.json
-          echo "✅ Updated GitHub release for $RELEASE_TAG"
+          echo "Updated GitHub release for $RELEASE_TAG"
         else
           curl -fsS -X POST \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -71,5 +77,5 @@ steps:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/Akawatmor/KPS-Enterprise/releases" \
             -d "$PAYLOAD" >/tmp/release-created.json
-          echo "✅ Created GitHub release for $RELEASE_TAG"
+          echo "Created GitHub release for $RELEASE_TAG"
         fi


### PR DESCRIPTION
…for SHA lookup

- Each list item in Woodpecker commands runs in a separate shell so variables do not persist between items; wrap all commands in a single '|' block so they share one shell session
- Replace git rev-parse with git rev-list -n 1 (works on shallow clones)
- Add git fetch --tags before rev-list so the tag exists locally
- Use CI_COMMIT_TAG directly (always set in tag events)